### PR TITLE
housekeeping: add missing antragstellerIds to types

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,6 +864,7 @@ In addition there is the value "SONSTIGE" ("other")
 ### Immobilie
 
     {
+        "antragstellerIds": [ String ],
         "bezeichnung": String,
         "darlehen": [
             {
@@ -885,6 +886,7 @@ In addition there is the value "SONSTIGE" ("other")
 ### Kind
 
     {
+        "antragstellerIds": [ String ],
         "kindergeldFuer": "ERSTES_ODER_ZWEITES_KIND" | "DRITTES_KIND" | "AB_VIERTEM_KIND",
         "name": String,
         "unterhaltseinnahmenMonatlich": BigDecimal


### PR DESCRIPTION
Das sind beides Haushaltspositionen, die einen Antragsteller zugeordnet werden müssen